### PR TITLE
JUnit and type tweaks

### DIFF
--- a/custom-types/commitlint-format.js
+++ b/custom-types/commitlint-format.js
@@ -11,6 +11,7 @@ declare module '@commitlint/format' {
 		valid: boolean,
 		input: string,
 		errors: RuleIssue[],
+		warnings: RuleIssue[],
 	};
 
 	declare type Report = {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,13 @@
 					"excludeArrowFunctions": true
 				}
 			],
+			"flowtype/require-return-type": [
+				"error",
+				"always",
+				{
+					"excludeArrowFunctions": true
+				}
+			],
 			"import/default": "off",
 			"import/no-unresolved": "off",
 			"import/no-extraneous-dependencies": "off",

--- a/packages/json/src/json.test.js
+++ b/packages/json/src/json.test.js
@@ -18,6 +18,7 @@ const exampleReport = {
 					message: 'type must be one of [feat,fix,test]',
 				},
 			],
+			warnings: [],
 		},
 	],
 };

--- a/packages/junit/src/junit.js
+++ b/packages/junit/src/junit.js
@@ -1,6 +1,11 @@
 // @flow
 import { type Report } from '@commitlint/format';
 
+type CreateElementOptions = {
+	noNewline?: boolean,
+	indent?: number,
+};
+
 /**
  * Indent the message with an indentation level.
  * This will add tabs based on this level.
@@ -11,6 +16,25 @@ import { type Report } from '@commitlint/format';
  */
 function indent(level: number, line: string): string {
 	return `${'  '.repeat(level)}${line}`;
+}
+
+/**
+ * Create a new XML element containing various properties.
+ * It can be configured to automatically add a newline, indentation and make it self closing.
+ *
+ * @param  {string} tag
+ * @param  {CreateElementOptions} options
+ * @param  {Object} attributes
+ * @return {string}
+ */
+function createElement(tag: string, options: CreateElementOptions, attributes: any): string {
+	const element = `<${tag}`;
+	const ending = options.noNewline ? '' : '\n';
+	const properties = Object.keys(attributes)
+		.map(key => `${key}="${attributes[key]}"`)
+		.join(' ');
+
+	return indent(options.indent || 0, `${element} ${properties}>${ending}`);
 }
 
 /**
@@ -25,29 +49,42 @@ function formatJunit(report?: Report): string {
 	output += indent(0, '<?xml version="1.0" encoding="utf-8"?>\n');
 	output += indent(0, '<testsuites>\n');
 
-	if (report && report.valid === false) {
-		const { errorCount } = report;
-
-		output += indent(1, `<testsuite name="commitlint" failures="${errorCount}" tests="${errorCount}">\n`);
+	if (report) {
+		output += createElement('testsuite', { indent: 1 }, {
+			name: 'commitlint',
+			failures: report.errorCount + report.warningCount,
+			tests: report.results.reduce(
+				(carry, result) => carry + ((result.errors.length + result.warnings.length) || 1),
+				0
+			),
+		});
 
 		report.results.forEach(result => {
-			const name = result.input.split('\n')[0];
-			const errorCount = result.errors.length;
+			const issues = [].concat(result.errors, result.warnings);
 
-			output += indent(2, `<testsuite name="${name}" failures="${errorCount}" tests="${errorCount}">\n`);
-
-			result.errors.forEach(error => {
-				const type = error.level === 2 ? 'error' : 'warning';
-
-				output += indent(3, `<testcase name="${error.name}">\n`);
-				output += indent(4, `<failure type="${type}">`);
-				output += `${error.message} (${error.name})\n`;
-				output += `\n${result.input}`;
-				output += '</failure>\n';
-				output += indent(3, '</testcase>\n');
+			output += createElement('testsuite', { indent: 2 }, {
+				name: result.input.split('\n')[0],
+				failures: issues.length,
+				tests: issues.length || 1,
 			});
 
-			output += indent(2, '</testsuite>\n');
+			if (issues.length > 0) {
+				issues.forEach(issue => {
+					const type = issue.level === 2 ? 'error' : 'warning';
+
+					output += indent(3, `<testcase name="${issue.name}">\n`);
+					output += indent(4, `<failure type="${type}">`);
+					output += `${issue.message} (${issue.name})\n`;
+					output += `\n${result.input}`;
+					output += '</failure>\n';
+					output += indent(3, '</testcase>\n');
+				});
+
+				output += indent(2, '</testsuite>\n');
+			} else {
+				output += indent(3, '<testcase name="valid" />\n');
+				output += indent(2, '</testsuite>\n');
+			}
 		});
 
 		output += indent(1, '</testsuite>\n');


### PR DESCRIPTION
### Linked issue
I accidentally forgot about successful tests in junit reports. The ESLint version, which I took as inspiration can't manage this but Commitlint can and should. It also includes the warnings property, which I encountered after debugging.