### PR TITLE
fix(junit): add testsuite errors property

### DIFF
--- a/packages/junit/src/junit.js
+++ b/packages/junit/src/junit.js
@@ -70,6 +70,7 @@ function formatJunit(report?: Report): string {
 	if (report) {
 		output += createElement('testsuite', { indent: 1 }, {
 			name: 'commitlint',
+			errors: 0,
 			failures: report.errorCount + report.warningCount,
 			tests: report.results.reduce(
 				(carry, result) => carry + ((result.errors.length + result.warnings.length) || 1),
@@ -82,6 +83,7 @@ function formatJunit(report?: Report): string {
 
 			output += createElement('testsuite', { indent: 2 }, {
 				name: result.input.split('\n')[0],
+				errors: 0,
 				failures: issues.length,
 				tests: issues.length || 1,
 			});

--- a/packages/junit/src/junit.test.js
+++ b/packages/junit/src/junit.test.js
@@ -41,7 +41,7 @@ test('returns string without report', t => {
 });
 
 test('contains testsuite summary', t => {
-	t.true(format(report).includes('testsuite name="commitlint" failures="2" tests="3"'));
+	t.true(format(report).includes('testsuite name="commitlint" errors="0" failures="2" tests="3"'));
 });
 
 test('contains testsuite summary without any tests', t => {
@@ -52,7 +52,7 @@ test('contains testsuite summary without any tests', t => {
 		results: [],
 	});
 
-	t.true(output.includes('testsuite name="commitlint" failures="0" tests="0"'));
+	t.true(output.includes('testsuite name="commitlint" errors="0" failures="0" tests="0"'));
 });
 
 test('contains testsuite summary with only valid tests', t => {
@@ -76,11 +76,11 @@ test('contains testsuite summary with only valid tests', t => {
 		],
 	});
 
-	t.true(output.includes('testsuite name="commitlint" failures="0" tests="2"'));
+	t.true(output.includes('testsuite name="commitlint" errors="0" failures="0" tests="2"'));
 });
 
 test('contains testsuite with only commit header', t => {
-	t.true(format(report).includes('testsuite name="foo: bar" failures="2" tests="2"'));
+	t.true(format(report).includes('testsuite name="foo: bar" errors="0" failures="2" tests="2"'));
 });
 
 test('contains testcase elements with rule name', t => {


### PR DESCRIPTION
### Linked issue
Some parsers are trying, and failing, to fetch the errors count from testsuites.
